### PR TITLE
Change regexp option from regexp to string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin injects a regexp to replace default module names.
 {
   "plugins": [
     ["babel-plugin-modules-regexp", {
-      regexp: /(foo)/,
+      regexp: '(foo)',
       substr: 'test/$1'
     }]
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ module.exports = function modulesRegexp() {
 		pre(file) {
 			const opts = file.opts;
 			const getModuleId = opts.getModuleId;
-			const regexp = this.opts.regexp;
+			const regexp = new RegExp(this.opts.regexp);
 			const substr = this.opts.substr;
 
 			opts.getModuleId = (moduleName) => {


### PR DESCRIPTION
Due to incompatibilities with babel 7 we need to pass options as simple types.

BREAKING CHANGE: change `regexp` option to string type